### PR TITLE
Standardize handling of credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ LD_FLAGS = " \
 ENV ?= kind
 IMG ?= etok
 TAG ?= $(VERSION)-$(RANDOM_SUFFIX)
-DEPLOY_FLAGS ?= --secret-file $(GOOGLE_APPLICATION_CREDENTIALS)
 KUBECTX=""
 
 # Override vars if ENV=gke
@@ -46,7 +45,7 @@ local: image push
 
 # Same as above - image still needs to be built and pushed/loaded
 .PHONY: deploy
-deploy: image push
+deploy: image push deploy-operator-secret
 	$(BUILD_BIN) install --context $(KUBECTX) --local --image $(IMG):$(TAG) $(DEPLOY_FLAGS) \
 		--backup-provider=gcs --gcs-bucket=$(BACKUP_BUCKET)
 
@@ -61,8 +60,29 @@ crds: build
 	$(BUILD_BIN) install --context $(KUBECTX) --local --crds-only
 
 .PHONY: undeploy
-undeploy: build
+undeploy: build delete-operator-secret
 	$(BUILD_BIN) install --local --dry-run | $(KUBECTL) delete -f - --wait --ignore-not-found=true
+
+
+# Deploy a secret containing GCP svc acc key, on kind, for the operator to use
+.PHONY: deploy-operator-secret
+deploy-operator-secret: delete-operator-secret create-operator-namespace
+ifeq ($(ENV),kind)
+	$(KUBECTL) --namespace=etok create secret generic etok --from-file=GOOGLE_CREDENTIALS=$(GOOGLE_APPLICATION_CREDENTIALS)
+endif
+
+.PHONY: delete-operator-secret
+delete-operator-secret:
+ifeq ($(ENV),kind)
+	$(KUBECTL) --namespace=etok delete secret etok --ignore-not-found
+endif
+
+# Create operator namespace, ignore already exists errors
+.PHONY: create-operator-namespace
+create-operator-namespace:
+ifeq ($(ENV),kind)
+	$(KUBECTL) create namespace etok 2>/dev/null || true
+endif
 
 .PHONY: e2e
 e2e: image push deploy

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ etok install --backup-provider=gcs --gcs-bucket=backups-bucket
 
 Note: only GCS is supported at present.
 
-Be sure to provide the appropriate credentials to the operator at install time. Either provide the path to a file containing a GCP service account key via the `--secret-file` flag, or setup workload identity (see below). The service account needs the following permissions on the bucket:
+Be sure to provide the appropriate credentials of a GCP service account to the operator at install time. Either [create a secret containing credentials](#credentials), or [setup workload identity](#workload-identity). The service account needs the following permissions on the bucket:
 
 ```
 storage.buckets.get
@@ -147,9 +147,9 @@ To opt a workspace out of automatic backup and restore, pass the `--ephemeral` f
 
 ## Credentials
 
-Etok looks for credentials in a secret named `etok`. If found, the credentials contained within are made available to terraform as environment variables.
+Etok looks for credentials in a secret named `etok` in the relevant namespace. The credentials contained within are made available as environment variables.
 
-For instance to set credentials for the [GCP provider](https://www.terraform.io/docs/providers/google/guides/provider_reference.html#full-reference):
+For instance to set credentials for the [Terraform GCP provider](https://www.terraform.io/docs/providers/google/guides/provider_reference.html#full-reference), or for making backups to GCS:
 
 ```
 kubectl create secret generic etok --from-file=GOOGLE_CREDENTIALS=[path to service account key]

--- a/cmd/install/deployment.go
+++ b/cmd/install/deployment.go
@@ -121,24 +121,12 @@ func deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 	deployment.Spec.Template.Labels = selector
 
 	if c.withSecret {
-		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
-			Name: "secrets",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: "etok",
+		deployment.Spec.Template.Spec.Containers[0].EnvFrom = append(deployment.Spec.Template.Spec.Containers[0].EnvFrom, corev1.EnvFromSource{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "etok",
 				},
 			},
-		})
-
-		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-			Name:      "secrets",
-			MountPath: "/secrets/secret-file.json",
-			SubPath:   "secret-file.json",
-		})
-
-		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-			Name:  "GOOGLE_APPLICATION_CREDENTIALS",
-			Value: "/secrets/secret-file.json",
 		})
 	}
 

--- a/cmd/install/deployment_test.go
+++ b/cmd/install/deployment_test.go
@@ -29,20 +29,10 @@ func TestDeployment(t *testing.T) {
 			namespace: "default",
 			opts:      []podTemplateOption{WithSecret(true)},
 			assertions: func(deploy *appsv1.Deployment) {
-				assert.Contains(t, deploy.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-					Name:  "GOOGLE_APPLICATION_CREDENTIALS",
-					Value: "/secrets/secret-file.json",
-				})
-				assert.Contains(t, deploy.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-					Name:      "secrets",
-					MountPath: "/secrets/secret-file.json",
-					SubPath:   "secret-file.json",
-				})
-				assert.Contains(t, deploy.Spec.Template.Spec.Volumes, corev1.Volume{
-					Name: "secrets",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: "etok",
+				assert.Contains(t, deploy.Spec.Template.Spec.Containers[0].EnvFrom, corev1.EnvFromSource{
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "etok",
 						},
 					},
 				})

--- a/cmd/install/resources.go
+++ b/cmd/install/resources.go
@@ -89,21 +89,3 @@ func adminClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 		},
 	}
 }
-
-func secret(namespace string, key []byte) *corev1.Secret {
-	secret := &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: corev1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "etok",
-			Namespace: namespace,
-		},
-		Data: map[string][]byte{
-			"secret-file.json": key,
-		},
-	}
-
-	return secret
-}


### PR DESCRIPTION
Standardize handling of credentials for both the operator and for workspaces/runs.

Currently the operator install command takes a path to a GCP service account via a `--secret-file` flag, whilst workspaces/runs look for a secret called `etok` containing environment variables.

This PR standardizes on the latter approach.

This will make it easier to support credentials other than a GCP service account key for the operator.